### PR TITLE
fix!: reuse existing handler rather than clobbering it

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Then run `:PlugInstall` to install the plugin.
 To set up the plugin, add the following line to where you manage your plugins:
 
 ```lua
-require('ts-error-translator').setup()
+require("ts-error-translator").setup()
 ```
 
 ## Configuration
@@ -56,10 +56,18 @@ default configuration for the plugin:
 
 If you want to override `tsserver`'s `textDocument/publishDiagnostics` handler
 `manually, ts-error-translator.nvim` exports a function,
-`require('ts-error-translator').lsp_publish_diagnostics_override`, that you can
-then use to override your lsp handlers.
+`require('ts-error-translator').translate_diagnostics`, that you can
+then use to override your lsp handlers. Here is example usage:
+
+```lua
+vim.lsp.handlers["textDocument/publishDiagnostics"] = function(err, result, ctx, config)
+  require("ts-error-translator").translate_diagnostics(err, result, ctx, config)
+  vim.lsp.diagnostic.on_publish_diagnostics(err, result, ctx, config)
+end
+```
 
 ## Related
+
 If you like this plugin and find it useful, you might also like my plugin, [tsc.nvim](https://github.com/dmmulroy/tsc.nvim), a Neovim plugin for seamless, asynchronous project-wide TypeScript type-checking using the TypeScript compiler (tsc)
 
 ## Contributing

--- a/lua/ts-error-translator/init.lua
+++ b/lua/ts-error-translator/init.lua
@@ -1,6 +1,9 @@
 -- Module M is the public API available for ts-error-translator.nvim
 local M = {}
 
+-- All language servers that are supported
+local supported_servers = { "tsserver", "vtsls" }
+
 -- Regex pattern for capturing numbered parameters like {0}, {1}, etc.
 local parameter_regex = "({%d})"
 
@@ -147,7 +150,7 @@ end
 M.translate_diagnostics = function(_, result, ctx, _)
   local client_name = get_lsp_client_name_by_id(ctx.client_id)
 
-  if client_name == "tsserver" then
+  if vim.tbl_contains(supported_servers, client_name) then
     vim.tbl_map(M.translate, result.diagnostics)
   end
 end

--- a/lua/ts-error-translator/init.lua
+++ b/lua/ts-error-translator/init.lua
@@ -117,24 +117,19 @@ end
 -- @param code number: The original compiler error number.
 -- @param message string: The original compiler message to parse.
 -- @return string: The translated or original error message.
-M.translate = function(code, message)
-  local improved_text_file = get_error_markdown_file(code)
+M.translate = function(diagnostic)
+  local improved_text_file = get_error_markdown_file(diagnostic.code)
 
-  if improved_text_file == nil then
-    return message
+  if improved_text_file then
+    local parsed = parse_markdown(improved_text_file)
+    local params = get_params(parsed["original"])
+
+    if #params > 0 then
+      diagnostic.message = translate_error_message(diagnostic.message, parsed["translated"], params)
+    end
   end
 
-  local parsed = parse_markdown(improved_text_file)
-
-  local params = get_params(parsed["original"])
-
-  if #params == 0 then
-    return message
-  end
-
-  local translated_error = translate_error_message(message, parsed["translated"], params)
-
-  return translated_error
+  return diagnostic
 end
 
 -- Retrieves the name of an LSP client given its client ID.
@@ -148,24 +143,15 @@ end
 
 -- Overrides the default LSP publishDiagnostics handler to translate diagnostics for TypeScript (tsserver).
 -- @param _ Unused parameter.
--- @param result table: The diagnostics result object.
--- @param ctx table: The context object containing LSP client information.
--- @param config table: The configuration object for the diagnostics.
-M.lsp_publish_diagnostics_override = function(_, result, ctx, config)
+-- @param result any: The diagnostics result object.
+-- @param ctx lsp.HandlerContext: The context object containing LSP client information.
+-- @param _ Unused parameter.
+M.translate_diagnostics = function(_, result, ctx, _)
   local client_name = get_lsp_client_name_by_id(ctx.client_id)
 
   if client_name == "tsserver" then
-    local updated_diagnostics = {}
-
-    for _, diagnostic in ipairs(result.diagnostics) do
-      diagnostic.message = M.translate(diagnostic.code, diagnostic.message)
-
-      table.insert(updated_diagnostics, diagnostic)
-    end
-    result.diagnostics = updated_diagnostics
+    vim.tbl_map(M.translate, result.diagnostics)
   end
-
-  vim.lsp.diagnostic.on_publish_diagnostics(_, result, ctx, config)
 end
 
 local DEFAULT_CONFIG = {
@@ -180,7 +166,11 @@ M.setup = function(opts)
   config = vim.tbl_deep_extend("force", config, DEFAULT_CONFIG, opts or {})
 
   if config.auto_override_publish_diagnostics == true then
-    vim.lsp.handlers["textDocument/publishDiagnostics"] = vim.lsp.with(M.lsp_publish_diagnostics_override, {})
+    local publish_diagnostics_handler = vim.lsp.handlers["textDocument/publishDiagnostics"]
+    vim.lsp.handlers["textDocument/publishDiagnostics"] = function(...)
+      M.translate_diagnostics(...)
+      publish_diagnostics_handler(...)
+    end
   end
 end
 

--- a/lua/ts-error-translator/init.lua
+++ b/lua/ts-error-translator/init.lua
@@ -124,9 +124,7 @@ M.translate = function(diagnostic)
     local parsed = parse_markdown(improved_text_file)
     local params = get_params(parsed["original"])
 
-    if #params > 0 then
-      diagnostic.message = translate_error_message(diagnostic.message, parsed["translated"], params)
-    end
+    diagnostic.message = translate_error_message(diagnostic.message, parsed["translated"], params)
   end
 
   return diagnostic


### PR DESCRIPTION
Hey! This is a great idea for a plugin! I was taking a look at the source code and noticed that you are essentially clobbering any previously set lsp handler for publishing diagnostics. This makes it so that it can be an addition.

I also did a bit of refactoring for performance and to simplify the code. Tables in lua are passed by reference so rather than making new tables and returning them it can all be done in place to save computation and space overhead!

Let me know what you think as this does change the API a bit which I added to the README to help users who are building it into their own lsp handler.

Oh lastly, I noticed that it is only replacing the message if parameters are found, I removed that check since a lot of the error messages don't have parameters (like 1002 for unclosed strings)

Also while I was here I added `vtsls` support (closes #16)