### PR TITLE
feat: add volar support

### DIFF
--- a/lua/ts-error-translator/init.lua
+++ b/lua/ts-error-translator/init.lua
@@ -2,7 +2,7 @@
 local M = {}
 
 -- All language servers that are supported
-local supported_servers = { "tsserver", "vtsls" }
+local supported_servers = { "tsserver", "vtsls", "volar" }
 
 -- Regex pattern for capturing numbered parameters like {0}, {1}, etc.
 local parameter_regex = "({%d})"


### PR DESCRIPTION
# Description

Firstly thank you for doing this amazing plugin, really appreciate. 

As a vue developer I use [volar takeover mode](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#volar) and disabled `tsserver`. Meaning that the current config does not allow me to use this plugin with `volar`

Since `volar` support `typescript server` out of the box, the only thing required is to simply add `volar` to `supported_servers`.

![image](https://github.com/dmmulroy/ts-error-translator.nvim/assets/33137074/31040915-5157-4c84-ba82-7c7c3f660d0b)

![image](https://github.com/dmmulroy/ts-error-translator.nvim/assets/33137074/199c3786-5414-4b83-9756-0b47a2a622c6)
