### PR TITLE
feat: add `svelte` and `astro` support

### DIFF
--- a/lua/ts-error-translator/init.lua
+++ b/lua/ts-error-translator/init.lua
@@ -3,6 +3,7 @@ local M = {}
 
 -- All language servers that are supported
 local supported_servers = {
+  "astro",
   "svelte",
   "tsserver",
   "typescript-tools",

--- a/lua/ts-error-translator/init.lua
+++ b/lua/ts-error-translator/init.lua
@@ -2,7 +2,13 @@
 local M = {}
 
 -- All language servers that are supported
-local supported_servers = { "tsserver", "typescript-tools", "vtsls", "volar" }
+local supported_servers = {
+  "svelte",
+  "tsserver",
+  "typescript-tools",
+  "volar",
+  "vtsls",
+}
 
 -- Regex pattern for capturing numbered parameters like {0}, {1}, etc.
 local parameter_regex = "({%d})"


### PR DESCRIPTION
It looks like the svelte language server is running `tsserver` under the hood so this also works in svelte!

![2024-04-04_13:33:18_screenshot](https://github.com/dmmulroy/ts-error-translator.nvim/assets/1591837/98288094-c35a-46a8-a68d-866484091c6b)
