### PR TITLE
fix: `tsserver` renamed to `ts_ls`

### DIFF
--- a/lua/ts-error-translator/init.lua
+++ b/lua/ts-error-translator/init.lua
@@ -5,7 +5,8 @@ local M = {}
 local supported_servers = {
   "astro",
   "svelte",
-  "tsserver",
+  "ts_ls",
+  "tsserver", -- deprecrated
   "typescript-tools",
   "volar",
   "vtsls",


### PR DESCRIPTION
`tsserver` in `lspconfig` was renamed to `ts_ls`: https://github.com/neovim/nvim-lspconfig/pull/3232

This leaves the deprecated name as well for backwards compatibility.