### PR TITLE
ref: updates function signature for vim.lsp.handlers[handler] to remove config

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ If you want to override `tsserver`'s `textDocument/publishDiagnostics` handler
 then use to override your lsp handlers. Here is example usage:
 
 ```lua
-vim.lsp.handlers["textDocument/publishDiagnostics"] = function(err, result, ctx, config)
-  require("ts-error-translator").translate_diagnostics(err, result, ctx, config)
-  vim.lsp.diagnostic.on_publish_diagnostics(err, result, ctx, config)
+vim.lsp.handlers["textDocument/publishDiagnostics"] = function(err, result, ctx)
+  require("ts-error-translator").translate_diagnostics(err, result, ctx)
+  vim.lsp.diagnostic.on_publish_diagnostics(err, result, ctx)
 end
 ```
 

--- a/lua/ts-error-translator/init.lua
+++ b/lua/ts-error-translator/init.lua
@@ -155,7 +155,7 @@ end
 -- @param result any: The diagnostics result object.
 -- @param ctx lsp.HandlerContext: The context object containing LSP client information.
 -- @param _ Unused parameter.
-M.translate_diagnostics = function(_, result, ctx, _)
+M.translate_diagnostics = function(_, result, ctx)
   local client_name = get_lsp_client_name_by_id(ctx.client_id)
 
   if vim.tbl_contains(supported_servers, client_name) then


### PR DESCRIPTION
This PR updates vim.lsp.handler[handler] function signature

- Should not break any existing overrides since config is last parameter and is unused

Closes #30 